### PR TITLE
Add data store delete + exists status on DataStore model

### DIFF
--- a/src/Exception/StoreNotFoundException.php
+++ b/src/Exception/StoreNotFoundException.php
@@ -1,0 +1,28 @@
+<?php
+namespace OneOffTech\GeoServer\Exception;
+
+/**
+ * Raised when a store cannot be found on the specific geoserver instance
+ */
+class StoreNotFoundException extends GeoServerClientException
+{
+    /**
+     *
+     * @param string $message
+     */
+    public function __construct($message)
+    {
+        parent::__construct($message, 404);
+    }
+
+
+    public static function datastore($name)
+    {
+        return new self("Data store [$name] not found.");
+    }
+    
+    public static function coveragestore($name)
+    {
+        return new self("Coverage store [$name] not found.");
+    }
+}

--- a/src/GeoServer.php
+++ b/src/GeoServer.php
@@ -146,6 +146,7 @@ final class GeoServer
      *
      * @param string $name The data store name
      * @return \OneOffTech\GeoServer\Models\DataStore
+     * @throws \OneOffTech\GeoServer\Exception\StoreNotFoundException if the data store to remove do not exists
      */
     public function deleteDatastore($name)
     {
@@ -196,6 +197,25 @@ final class GeoServer
         $this->putFile($route, $data);
 
         return $this->feature($data->name);
+    }
+
+    /**
+     * Delete a GeoFile from the GeoServer instance
+     * 
+     * Deletes the corresponding store based on the GeoType format
+     * 
+     * @param GeoFile $data The GeoFile to delete
+     * @return bool
+     * @throws \OneOffTech\GeoServer\Exception\StoreNotFoundException if the store, that corresponds to the file, do not exists
+     */
+    public function remove(GeoFile $data)
+    {
+        if($data->type === GeoType::VECTOR){
+            $this->deleteDatastore($data->name);
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/src/Models/DataStore.php
+++ b/src/Models/DataStore.php
@@ -57,4 +57,16 @@ class DataStore extends Model
      * @JMS\SerializedName("connectionParameters")
      */
     public $connectionParameters;
+
+
+    /**
+     * Indicates if the data store exists.
+     *
+     * It is used to indicate the deletion status.
+     * The $exists value is set to false after succesfull deletion.
+     *
+     * @var bool
+     * @JMS\Exclude
+     */
+    public $exists = true;
 }

--- a/tests/Integration/GeoServerDataStoresTest.php
+++ b/tests/Integration/GeoServerDataStoresTest.php
@@ -96,4 +96,18 @@ class GeoServerDataStoresTest extends TestCase
 
         $datastore = $this->geoserver->datastore('some_name');
     }
+
+    public function test_shapefile_can_be_uploaded_and_deleted()
+    {
+        $datastoreName = 'shapefile_test' . time();
+        $data = GeoFile::from(__DIR__ . '/../fixtures/shapefile.shp')->name($datastoreName);
+
+        $feature = $this->geoserver->upload($data);
+
+        $this->assertInstanceOf(Feature::class, $feature);
+        
+        $deleteResult = $this->geoserver->remove($data);
+
+        $this->assertTrue($deleteResult, "GeoFile not deleted");
+    }
 }


### PR DESCRIPTION
This pull requests add

- `deleteDatastore($name)` method to remove a datastore from the GeoServer
- `DataStore::$exists` property to signal the status change after deletion on the returned datastore instance
- `remove(Geofile $file)` method to remove the correct store based on the file type