### PR TITLE
Add GeoServer 2.15.x compatibility 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ env:
   matrix:
     - COMPOSER_FLAGS="--prefer-lowest"
     - COMPOSER_FLAGS="--prefer-stable"
+    - COMPOSER_FLAGS="--prefer-stable" GEOSERVER_TAG="2.15.2"
 
 matrix:
   exclude:

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,8 @@
         "friendsofphp/php-cs-fixer": "^2.12",
         "symfony/var-dumper": "^4.1",
         "guzzlehttp/psr7": "^1.6",
-        "http-interop/http-factory-guzzle": "^1.0"
+        "http-interop/http-factory-guzzle": "^1.0",
+        "undemanding/difference": "^1.1"
     },
     "extra": {
         "branch-alias" : {

--- a/src/GeoServer.php
+++ b/src/GeoServer.php
@@ -510,26 +510,22 @@ final class GeoServer
      */
     public function uploadStyle(StyleFile $file)
     {
-        $initialPostRoute = $this->routes->url("workspaces/$this->workspace/styles");
-        $filePutRoute = $this->routes->url("workspaces/$this->workspace/styles/$file->name");
+        $filePostRoute = $this->routes->url("workspaces/$this->workspace/styles");
 
         try {
-            $postResponse = $this->post($initialPostRoute, [
-                'style' => [
-                    'name' => $file->name,
-                    'filename' => $file->originalName,
-                ]
-            ]);
+            $postFileResponse = $this->postFile($filePostRoute . '?name=' . $file->name, $file);
+
         } catch (ErrorResponseException $ex) {
             // we receive a 500 error response if the style already exists
             if ($ex->getData() === "Style named '$file->name' already exists in workspace $this->workspace") {
                 throw StyleAlreadyExistsException::style($file->name, $this->workspace);
             }
+            if (strpos($ex->getData(), "Style $file->name already exists") !== false) {
+                throw StyleAlreadyExistsException::style($file->name, $this->workspace);
+            }
 
             throw $ex;
         }
-
-        $putFileResponse = $this->putFile($filePutRoute, $file);
 
         return $this->style($file->name);
     }

--- a/src/Http/InteractsWithHttp.php
+++ b/src/Http/InteractsWithHttp.php
@@ -157,6 +157,15 @@ trait InteractsWithHttp
 
         return $this->deserialize($response, $class);
     }
+    
+    protected function postFile($route, $data, $class = null)
+    {
+        $request = $this->messageFactory->createRequest('POST', $route, ['Content-Type' => $data->normalizedMimeType], $data->content());
+
+        $response = $this->handleRequest($request);
+
+        return $this->deserialize($response, $class);
+    }
 
     protected function delete($route, $class = null)
     {

--- a/tests/Integration/GeoServerStylesTest.php
+++ b/tests/Integration/GeoServerStylesTest.php
@@ -45,7 +45,7 @@ class GeoServerStylesTest extends TestCase
         $this->assertInstanceOf(Style::class, $style);
         $this->assertEquals($styleName, $style->name);
         $this->assertEquals(getenv('GEOSERVER_WORKSPACE'), $style->workspace);
-        $this->assertEquals('style.sld', $style->filename);
+        $this->assertEquals('style_test.sld', $style->filename);
         $this->assertEquals('sld', $style->format);
         $this->assertEquals('1.0.0', $style->version);
         $this->assertTrue($style->exists, "Style not existing");
@@ -63,7 +63,7 @@ class GeoServerStylesTest extends TestCase
         $this->assertInstanceOf(Style::class, $style);
         $this->assertEquals($styleName, $style->name);
         $this->assertEquals(getenv('GEOSERVER_WORKSPACE'), $style->workspace);
-        $this->assertEquals('style.sld', $style->filename);
+        $this->assertEquals('style_test.sld', $style->filename);
         $this->assertEquals('sld', $style->format);
         $this->assertEquals('1.0.0', $style->version);
         $this->assertTrue($style->exists, "Style not existing");
@@ -93,7 +93,7 @@ class GeoServerStylesTest extends TestCase
         $this->assertInstanceOf(Style::class, $style);
         $this->assertEquals($styleName, $style->name);
         $this->assertEquals(getenv('GEOSERVER_WORKSPACE'), $style->workspace);
-        $this->assertEquals('style.sld', $style->filename);
+        $this->assertEquals('style_test.sld', $style->filename);
         $this->assertEquals('sld', $style->format);
         $this->assertEquals('1.0.0', $style->version);
         $this->assertFalse($style->exists, "Style still exists after deletion");

--- a/tests/Integration/GeoServerWmsTest.php
+++ b/tests/Integration/GeoServerWmsTest.php
@@ -24,12 +24,14 @@ namespace Tests\Integration;
 use Tests\TestCase;
 use GuzzleHttp\Psr7\Request;
 use OneOffTech\GeoServer\GeoFile;
+use Undemanding\Difference\Image;
 use Psr\Http\Message\RequestInterface;
 use Tests\Concern\SetupIntegrationTest;
 use OneOffTech\GeoServer\Models\Feature;
 use OneOffTech\GeoServer\Models\DataStore;
 use OneOffTech\GeoServer\Models\Workspace;
 use OneOffTech\GeoServer\Support\ImageResponse;
+use Undemanding\Difference\Method\EuclideanDistance;
 use OneOffTech\GeoServer\Exception\InvalidDataException;
 use OneOffTech\GeoServer\Exception\ErrorResponseException;
 
@@ -95,8 +97,20 @@ class GeoServerWmsTest extends TestCase
         $this->assertEquals(300, $width);
         $this->assertEquals(300, $height);
 
-        $this->assertEquals(md5(file_get_contents(__DIR__ . '/../fixtures/shapefile_thumbnail.png')), md5($thumbnail->asString()));
+        // compare the image difference against a reference thumbnail
 
+        $image1 = new Image(__DIR__ . '/../fixtures/shapefile_thumbnail.png');
+
+        file_put_contents(__DIR__ . '/../fixtures/shapefile_thumbnail_from_geoserver.png', $thumbnail->asString());
+
+        $image2 = new Image(__DIR__ . '/../fixtures/shapefile_thumbnail_from_geoserver.png');
+
+        $difference = $image1->difference($image2, new EuclideanDistance());
+
+        unlink(__DIR__ . '/../fixtures/shapefile_thumbnail_from_geoserver.png');
         $deleteResult = $this->geoserver->remove($file);
+
+        // considering a 20% difference as acceptable
+        $this->assertTrue($difference->percentage() < 20);
     }
 }

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,14 +1,14 @@
 ## Test environment
 ## This docker compose starts the necessary services to run integration tests
 
-version: "2"
+version: "2.1"
 
 networks:
   internal:
 
 services:
   geoserver:
-    image: "kartoza/geoserver:2.13.0"
+    image: "kartoza/geoserver:${GEOSERVER_TAG:-2.13.0}"
     env_file:
         - geoserver.env
     ports:


### PR DESCRIPTION
Closes #19 

This pull request adds automated tests against GeoServer 2.15.x and fix some compatibility problems when uploading style files.

In particular the following changes were made:

- Upload directly the style file in the workspace without first define an empty style placeholder
- Use the given style name (via `StyleFile->name()`) for the name of the style and the filename (**possible breaking change**)
- Use image difference as a way to compare the generated thumbnail against the default thumbnail